### PR TITLE
Update to Rack API v0.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,14 @@
+SLUG = "Aepelzens Modules"
+VERSION = 0.6.0dev
+
 # FLAGS += -D v040
 FLAGS += -D v_050_dev
 
-SOURCES = $(wildcard src/*.cpp)
+LDFLAGS += -lsamplerate
 
-include ../../plugin.mk
+SOURCES += $(wildcard src/*.cpp)
 
-dist: all
-	mkdir -p dist/aepelzen
-	cp LICENSE* dist/aepelzen/
-	cp plugin.* dist/aepelzen/
-	cp -R res dist/aepelzen/
+DISTRIBUTABLES += $(wildcard LICENSE*) res
+
+RACK_DIR ?= ../..
+include $(RACK_DIR)/plugin.mk

--- a/src/Dice.cpp
+++ b/src/Dice.cpp
@@ -132,9 +132,11 @@ void Dice::step() {
 }
 
 
-DiceWidget::DiceWidget() {
-    Dice *module = new Dice();
-    setModule(module);
+struct DiceWidget : ModuleWidget {
+	DiceWidget(Dice *module);
+};
+
+DiceWidget::DiceWidget(Dice *module) : ModuleWidget(module) {
     box.size = Vec(8 * RACK_GRID_WIDTH, RACK_GRID_HEIGHT);
 
     {
@@ -144,16 +146,18 @@ DiceWidget::DiceWidget() {
 	addChild(panel);
     }
 
-    addParam(createParam<LEDButton>(Vec(10, 5), module, Dice::RESET_PARAM, 0.0, 1.0, 0.0));
+    addParam(ParamWidget::create<LEDButton>(Vec(10, 5), module, Dice::RESET_PARAM, 0.0, 1.0, 0.0));
     
     for(int y=0;y<NUM_CHANNELS;y++) {
 	for(int i=0;i<NUM_STEPS;i++) {
-	    addParam(createParam<Trimpot>(Vec(10 + y*27, 30 + i*28), module, Dice::COLUMN1_PARAM + y *NUM_STEPS + i, 0.0, 1.0, 0.0));
-	    addChild(createLight<SmallLight<RedLight>>(Vec(16 + y*27, 50 + i*28), module, Dice::STEP_LIGHT + y *NUM_STEPS + i));
+	    addParam(ParamWidget::create<Trimpot>(Vec(10 + y*27, 30 + i*28), module, Dice::COLUMN1_PARAM + y *NUM_STEPS + i, 0.0, 1.0, 0.0));
+	    addChild(ModuleLightWidget::create<SmallLight<RedLight>>(Vec(16 + y*27, 50 + i*28), module, Dice::STEP_LIGHT + y *NUM_STEPS + i));
 	}
-	addParam(createParam<Trimpot>(Vec(10 + y*27, 265), module, Dice::CHANNEL_STEPS_PARAM + y, 1.0, 8.0, 8.0));
-	addParam(createParam<Trimpot>(Vec(10 + y*27, 290), module, Dice::CHANNEL_MODE_PARAM + y, 0, 5, 0));
-	addInput(createInput<PJ301MPort>(Vec(7+y*27, 310), module, Dice::CHANNEL_CLOCK_INPUT + y));
-	addOutput(createOutput<PJ301MPort>(Vec(7 + y*27, 345), module, Dice::GATE_OUTPUT + y));
+	addParam(ParamWidget::create<Trimpot>(Vec(10 + y*27, 265), module, Dice::CHANNEL_STEPS_PARAM + y, 1.0, 8.0, 8.0));
+	addParam(ParamWidget::create<Trimpot>(Vec(10 + y*27, 290), module, Dice::CHANNEL_MODE_PARAM + y, 0, 5, 0));
+	addInput(Port::create<PJ301MPort>(Vec(7+y*27, 310), Port::INPUT, module, Dice::CHANNEL_CLOCK_INPUT + y));
+	addOutput(Port::create<PJ301MPort>(Vec(7 + y*27, 345), Port::OUTPUT, module, Dice::GATE_OUTPUT + y));
     }
 }
+
+Model *modelDice = Model::create<Dice, DiceWidget>("Aepelzens Modules", "Dice", "Probability Sequencer", SEQUENCER_TAG);

--- a/src/Erwin.cpp
+++ b/src/Erwin.cpp
@@ -106,9 +106,11 @@ struct MuteLight : BASE {
 	}
 };
 
-ErwinWidget::ErwinWidget() {
-  Erwin *module = new Erwin();
-  setModule(module);
+struct ErwinWidget : ModuleWidget {
+	ErwinWidget(Erwin *module);
+};
+
+ErwinWidget::ErwinWidget(Erwin *module) : ModuleWidget(module) {
   box.size = Vec(15*8, 380);
 
   {
@@ -118,39 +120,41 @@ ErwinWidget::ErwinWidget() {
     addChild(panel);
   }
 
-  addChild(createScrew<ScrewSilver>(Vec(15, 0)));
-  addChild(createScrew<ScrewSilver>(Vec(box.size.x-30, 0)));
-  addChild(createScrew<ScrewSilver>(Vec(15, 365)));
-  addChild(createScrew<ScrewSilver>(Vec(box.size.x-30, 365)));
+  addChild(Widget::create<ScrewSilver>(Vec(15, 0)));
+  addChild(Widget::create<ScrewSilver>(Vec(box.size.x-30, 0)));
+  addChild(Widget::create<ScrewSilver>(Vec(15, 365)));
+  addChild(Widget::create<ScrewSilver>(Vec(box.size.x-30, 365)));
 
-  addInput(createInput<PJ301MPort>(Vec(22.5, 42), module, Erwin::TRANSPOSE_INPUT));
-  addInput(createInput<PJ301MPort>(Vec(76, 42), module, Erwin::SEMI_INPUT));
+  addInput(Port::create<PJ301MPort>(Vec(22.5, 42), Port::INPUT, module, Erwin::TRANSPOSE_INPUT));
+  addInput(Port::create<PJ301MPort>(Vec(76, 42), Port::INPUT, module, Erwin::SEMI_INPUT));
 
   for(int i=0;i<4;i++) {
-    addOutput(createOutput<PJ301MPort>(Vec(76, 235 + i*30), module, Erwin::OUT_OUTPUT + i));
-    addInput(createInput<PJ301MPort>(Vec(76, 100 +i*30), module, Erwin::IN_INPUT + i));
+    addOutput(Port::create<PJ301MPort>(Vec(76, 235 + i*30), Port::OUTPUT, module, Erwin::OUT_OUTPUT + i));
+    addInput(Port::create<PJ301MPort>(Vec(76, 100 +i*30), Port::INPUT, module, Erwin::IN_INPUT + i));
   }
 
-  addParam(createParam<Trimpot>(Vec(16, 90), module, Erwin::CHANNEL_TRANSPOSE_PARAM, -4, 4, 0));
-  addParam(createParam<Trimpot>(Vec(38, 90), module, Erwin::CHANNEL_TRANSPOSE_PARAM + 1, -4, 4, 0));
-  addParam(createParam<Trimpot>(Vec(16, 117.5), module, Erwin::CHANNEL_TRANSPOSE_PARAM + 2, -4, 4, 0));
-  addParam(createParam<Trimpot>(Vec(38, 117.5), module, Erwin::CHANNEL_TRANSPOSE_PARAM + 3, -4, 4, 0));
+  addParam(ParamWidget::create<Trimpot>(Vec(16, 90), module, Erwin::CHANNEL_TRANSPOSE_PARAM, -4, 4, 0));
+  addParam(ParamWidget::create<Trimpot>(Vec(38, 90), module, Erwin::CHANNEL_TRANSPOSE_PARAM + 1, -4, 4, 0));
+  addParam(ParamWidget::create<Trimpot>(Vec(16, 117.5), module, Erwin::CHANNEL_TRANSPOSE_PARAM + 2, -4, 4, 0));
+  addParam(ParamWidget::create<Trimpot>(Vec(38, 117.5), module, Erwin::CHANNEL_TRANSPOSE_PARAM + 3, -4, 4, 0));
 
   //Note buttons
   int white=0;
   int black = 0;
   for(int i=0; i<12; i++) {
     if (i == 1 || i == 3 || i == 6 || i == 8 || i == 10 ) {
-      addParam(createParam<LEDBezel>(Vec(10,311.5 - black*30), module, Erwin::NOTE_PARAM + i, 0.0, 1.0, 0.0));
-      addChild(createLight<MuteLight<GreenLight>>(Vec(12, 313.5 - black*30), module, Erwin::NOTE_LIGHT+i));
+      addParam(ParamWidget::create<LEDBezel>(Vec(10,311.5 - black*30), module, Erwin::NOTE_PARAM + i, 0.0, 1.0, 0.0));
+      addChild(ModuleLightWidget::create<MuteLight<GreenLight>>(Vec(12, 313.5 - black*30), module, Erwin::NOTE_LIGHT+i));
       black++;
     }
     else {
       if(i == 4)
 	black++;
-      addParam(createParam<LEDBezel>(Vec(35,326.5 - white*30), module, Erwin::NOTE_PARAM + i, 0.0, 1.0, 0.0));
-      addChild(createLight<MuteLight<GreenLight>>(Vec(37, 328.5 - white*30), module, Erwin::NOTE_LIGHT+i));
+      addParam(ParamWidget::create<LEDBezel>(Vec(35,326.5 - white*30), module, Erwin::NOTE_PARAM + i, 0.0, 1.0, 0.0));
+      addChild(ModuleLightWidget::create<MuteLight<GreenLight>>(Vec(37, 328.5 - white*30), module, Erwin::NOTE_LIGHT+i));
       white++;
     }
   }
 }
+
+Model *modelErwin = Model::create<Erwin, ErwinWidget>("Aepelzens Modules", "Erwin", "Erwin", UTILITY_TAG);

--- a/src/GateSeq.cpp
+++ b/src/GateSeq.cpp
@@ -259,9 +259,11 @@ struct BigLight : BASE {
 	}
 };
 
-GateSeqWidget::GateSeqWidget() {
-    GateSeq *module = new GateSeq();
-    setModule(module);
+struct GateSeqWidget : ModuleWidget {
+	GateSeqWidget(GateSeq *module);
+};
+
+GateSeqWidget::GateSeqWidget(GateSeq *module) : ModuleWidget(module) {
     box.size = Vec(525, 380);
 
     {
@@ -271,53 +273,53 @@ GateSeqWidget::GateSeqWidget() {
 	addChild(panel);
     }
 
-    addChild(createScrew<ScrewSilver>(Vec(15, 0)));
-    addChild(createScrew<ScrewSilver>(Vec(box.size.x-30, 0)));
-    addChild(createScrew<ScrewSilver>(Vec(15, 365)));
-    addChild(createScrew<ScrewSilver>(Vec(box.size.x-30, 365)));
+    addChild(Widget::create<ScrewSilver>(Vec(15, 0)));
+    addChild(Widget::create<ScrewSilver>(Vec(box.size.x-30, 0)));
+    addChild(Widget::create<ScrewSilver>(Vec(15, 365)));
+    addChild(Widget::create<ScrewSilver>(Vec(box.size.x-30, 365)));
 
-    addParam(createParam<RoundSmallBlackKnob>(Vec(15, 50), module, GateSeq::CLOCK_PARAM, -2.0, 10.0, 2.0));
-    addParam(createParam<LEDBezel>(Vec(65, 55), module, GateSeq::RUN_PARAM, 0.0, 1.0, 0.0));
-    addChild(createLight<BigLight<GreenLight>>(Vec(67.5, 57.5), module, GateSeq::RUNNING_LIGHT));
-    addParam(createParam<LEDBezel>(Vec(96.5, 55), module, GateSeq::RESET_PARAM, 0.0, 1.0, 0.0));
-    addChild(createLight<BigLight<GreenLight>>(Vec(99, 57.5), module, GateSeq::RESET_LIGHT));
+    addParam(ParamWidget::create<RoundSmallBlackKnob>(Vec(15, 50), module, GateSeq::CLOCK_PARAM, -2.0, 10.0, 2.0));
+    addParam(ParamWidget::create<LEDBezel>(Vec(65, 55), module, GateSeq::RUN_PARAM, 0.0, 1.0, 0.0));
+    addChild(ModuleLightWidget::create<BigLight<GreenLight>>(Vec(67.5, 57.5), module, GateSeq::RUNNING_LIGHT));
+    addParam(ParamWidget::create<LEDBezel>(Vec(96.5, 55), module, GateSeq::RESET_PARAM, 0.0, 1.0, 0.0));
+    addChild(ModuleLightWidget::create<BigLight<GreenLight>>(Vec(99, 57.5), module, GateSeq::RESET_LIGHT));
 
-    addInput(createInput<PJ301MPort>(Vec(32, 99-1), module, GateSeq::CLOCK_INPUT));
-    addInput(createInput<PJ301MPort>(Vec(5, 99-1), module, GateSeq::EXT_CLOCK_INPUT));
-    addOutput(createOutput<PJ301MPort>(Vec(63.5, 98), module, GateSeq::CLOCK_OUTPUT));
-    addInput(createInput<PJ301MPort>(Vec(95.0, 98), module, GateSeq::RESET_INPUT));
-    addInput(createInput<PJ301MPort>(Vec(133, 98), module, GateSeq::PATTERN_INPUT));
+    addInput(Port::create<PJ301MPort>(Vec(32, 99-1), Port::INPUT, module, GateSeq::CLOCK_INPUT));
+    addInput(Port::create<PJ301MPort>(Vec(5, 99-1), Port::INPUT, module, GateSeq::EXT_CLOCK_INPUT));
+    addOutput(Port::create<PJ301MPort>(Vec(63.5, 98), Port::OUTPUT, module, GateSeq::CLOCK_OUTPUT));
+    addInput(Port::create<PJ301MPort>(Vec(95.0, 98), Port::INPUT, module, GateSeq::RESET_INPUT));
+    addInput(Port::create<PJ301MPort>(Vec(133, 98), Port::INPUT, module, GateSeq::PATTERN_INPUT));
 
-    addParam(createParam<LEDBezel>(Vec(175, 55), module, GateSeq::COPY_PARAM , 0.0, 1.0, 0.0));
-    addChild(createLight<BigLight<YellowLight>>(Vec(177.5, 57.5), module, GateSeq::COPY_LIGHT));
-    addParam(createParam<LEDBezel>(Vec(175, 98), module, GateSeq::INIT_PARAM , 0.0, 1.0, 0.0));
+    addParam(ParamWidget::create<LEDBezel>(Vec(175, 55), module, GateSeq::COPY_PARAM , 0.0, 1.0, 0.0));
+    addChild(ModuleLightWidget::create<BigLight<YellowLight>>(Vec(177.5, 57.5), module, GateSeq::COPY_LIGHT));
+    addParam(ParamWidget::create<LEDBezel>(Vec(175, 98), module, GateSeq::INIT_PARAM , 0.0, 1.0, 0.0));
 
-    addParam(createParam<LEDBezel>(Vec(205, 98), module, GateSeq::LENGTH_PARAM , 0.0, 1.0, 0.0));
-    addChild(createLight<BigLight<RedLight>>(Vec(207.5, 100.5), module, GateSeq::LENGTH_LIGHT));
-    addParam(createParam<CKSS>(Vec(139, 55), module, GateSeq::PATTERN_SWITCH_MODE_PARAM , 0.0, 1.0, 0.0));
+    addParam(ParamWidget::create<LEDBezel>(Vec(205, 98), module, GateSeq::LENGTH_PARAM , 0.0, 1.0, 0.0));
+    addChild(ModuleLightWidget::create<BigLight<RedLight>>(Vec(207.5, 100.5), module, GateSeq::LENGTH_LIGHT));
+    addParam(ParamWidget::create<CKSS>(Vec(139, 55), module, GateSeq::PATTERN_SWITCH_MODE_PARAM , 0.0, 1.0, 0.0));
 
-    addParam(createParam<LEDBezel>(Vec(465, 55), module, GateSeq::MERGE_PARAM , 0.0, 1.0, 0.0));
-    addChild(createLight<BigLight<RedLight>>(Vec(467.5, 57.5), module, GateSeq::MERGE_LIGHT));
-    addParam(createParam<RoundSmallBlackKnob>(Vec(463, 90), module, GateSeq::MERGE_MODE_PARAM , 0.0, 5.0, 0.0));
+    addParam(ParamWidget::create<LEDBezel>(Vec(465, 55), module, GateSeq::MERGE_PARAM , 0.0, 1.0, 0.0));
+    addChild(ModuleLightWidget::create<BigLight<RedLight>>(Vec(467.5, 57.5), module, GateSeq::MERGE_LIGHT));
+    addParam(ParamWidget::create<RoundSmallBlackKnob>(Vec(463, 90), module, GateSeq::MERGE_MODE_PARAM , 0.0, 5.0, 0.0));
 
     //pattern/bank buttons
     for(int i=0;i<8;i++) {
-	addParam(createParam<LEDBezel>(Vec(252 + i*24, 55), module, GateSeq::BANK_PARAM + i, 0.0, 1.0, 0.0));
-	addChild(createLight<BigLight<GreenLight>>(Vec(254.5 + i*24, 57.5), module, GateSeq::BANK_LIGHTS + i));
-	addParam(createParam<LEDBezel>(Vec(252 + i*24, 98), module, GateSeq::PATTERN_PARAM + i, 0.0, 1.0, 0.0));
-	addChild(createLight<BigLight<GreenLight>>(Vec(254.5 + i*24, 100.5), module, GateSeq::PATTERN_LIGHTS + i));
+	addParam(ParamWidget::create<LEDBezel>(Vec(252 + i*24, 55), module, GateSeq::BANK_PARAM + i, 0.0, 1.0, 0.0));
+	addChild(ModuleLightWidget::create<BigLight<GreenLight>>(Vec(254.5 + i*24, 57.5), module, GateSeq::BANK_LIGHTS + i));
+	addParam(ParamWidget::create<LEDBezel>(Vec(252 + i*24, 98), module, GateSeq::PATTERN_PARAM + i, 0.0, 1.0, 0.0));
+	addChild(ModuleLightWidget::create<BigLight<GreenLight>>(Vec(254.5 + i*24, 100.5), module, GateSeq::PATTERN_LIGHTS + i));
     }
 
     for (int y = 0; y < NUM_CHANNELS; y++) {
 	for (int x = 0; x < NUM_STEPS; x++) {
 	    int i = y*NUM_STEPS+x;
-	    addParam(createParam<LEDBezel>(Vec(62 + x*25, 155+y*25), module, GateSeq::GATE1_PARAM + i, 0.0, 1.0, 0.0));
-	    addChild(createLight<BigLight<GreenRedLight>>(Vec(62 + x*25 + 2.5, 155+y*25+2.5), module, GateSeq::GATE_LIGHTS + 2*i));
+	    addParam(ParamWidget::create<LEDBezel>(Vec(62 + x*25, 155+y*25), module, GateSeq::GATE1_PARAM + i, 0.0, 1.0, 0.0));
+	    addChild(ModuleLightWidget::create<BigLight<GreenRedLight>>(Vec(62 + x*25 + 2.5, 155+y*25+2.5), module, GateSeq::GATE_LIGHTS + 2*i));
 	}
-	addInput(createInput<PJ301MPort>(Vec(5, 155+y*25 - 1.5), module, GateSeq::CHANNEL_CLOCK_INPUT + y));
-	addInput(createInput<PJ301MPort>(Vec(32, 155+y*25 - 1.5), module, GateSeq::CHANNEL_PROB_INPUT + y));
-	addOutput(createOutput<PJ301MPort>(Vec(465, 155+y*25 - 1.5), module, GateSeq::GATE1_OUTPUT + y));
-	addParam(createParam<Trimpot>(Vec(495, 155+y*25 + 1.5), module, GateSeq::CHANNEL_PROB_PARAM + y, 0.0, 1.0, 1.0));
+	addInput(Port::create<PJ301MPort>(Vec(5, 155+y*25 - 1.5), Port::INPUT, module, GateSeq::CHANNEL_CLOCK_INPUT + y));
+	addInput(Port::create<PJ301MPort>(Vec(32, 155+y*25 - 1.5), Port::INPUT, module, GateSeq::CHANNEL_PROB_INPUT + y));
+	addOutput(Port::create<PJ301MPort>(Vec(465, 155+y*25 - 1.5), Port::OUTPUT, module, GateSeq::GATE1_OUTPUT + y));
+	addParam(ParamWidget::create<Trimpot>(Vec(495, 155+y*25 + 1.5), module, GateSeq::CHANNEL_PROB_PARAM + y, 0.0, 1.0, 1.0));
     }
 }
 
@@ -514,3 +516,5 @@ void GateSeq::fromJson(json_t *rootJ) {
 
     currentPattern = &patterns[8*bank + pattern];
 }
+
+Model *modelGateSeq = Model::create<GateSeq, GateSeqWidget>("Aepelzens Modules", "GateSEQ", "Gate Sequencer", SEQUENCER_TAG);

--- a/src/QuadSeq.cpp
+++ b/src/QuadSeq.cpp
@@ -243,9 +243,11 @@ void QuadSeq::step() {
 }
 
 
-QuadSeqWidget::QuadSeqWidget() {
-  QuadSeq *module = new QuadSeq();
-  setModule(module);
+struct QuadSeqWidget : ModuleWidget {
+	QuadSeqWidget(QuadSeq *module);
+};
+
+QuadSeqWidget::QuadSeqWidget(QuadSeq *module) : ModuleWidget(module) {
   box.size = Vec(15*22, 380);
 
   {
@@ -255,34 +257,36 @@ QuadSeqWidget::QuadSeqWidget() {
     addChild(panel);
   }
 
-  // addChild(createScrew<ScrewSilver>(Vec(5, 0)));
-  // addChild(createScrew<ScrewSilver>(Vec(box.size.x-20, 0)));
-  // addChild(createScrew<ScrewSilver>(Vec(5, 365)));
-  // addChild(createScrew<ScrewSilver>(Vec(box.size.x-20, 365)));
+  // addChild(Widget::create<ScrewSilver>(Vec(5, 0)));
+  // addChild(Widget::create<ScrewSilver>(Vec(box.size.x-20, 0)));
+  // addChild(Widget::create<ScrewSilver>(Vec(5, 365)));
+  // addChild(Widget::create<ScrewSilver>(Vec(box.size.x-20, 365)));
 
   //original 56
-  addParam(createParam<RoundSmallBlackKnob>(Vec(56, 35), module, QuadSeq::CLOCK_PARAM, -2.0, 6.0, 2.0));
-  addParam(createParam<LEDButton>(Vec(60, 82), module, QuadSeq::RUN_PARAM, 0.0, 1.0, 0.0));
-  addChild(createLight<MediumLight<GreenLight>>(Vec(64.4, 86.4), module, QuadSeq::RUNNING_LIGHT));
-  addParam(createParam<LEDButton>(Vec(60, 120), module, QuadSeq::RESET_PARAM, 0.0, 1.0, 0.0));
-  addChild(createLight<MediumLight<GreenLight>>(Vec(64.4, 124.4), module, QuadSeq::RESET_LIGHT));
+  addParam(ParamWidget::create<RoundSmallBlackKnob>(Vec(56, 35), module, QuadSeq::CLOCK_PARAM, -2.0, 6.0, 2.0));
+  addParam(ParamWidget::create<LEDButton>(Vec(60, 82), module, QuadSeq::RUN_PARAM, 0.0, 1.0, 0.0));
+  addChild(ModuleLightWidget::create<MediumLight<GreenLight>>(Vec(64.4, 86.4), module, QuadSeq::RUNNING_LIGHT));
+  addParam(ParamWidget::create<LEDButton>(Vec(60, 120), module, QuadSeq::RESET_PARAM, 0.0, 1.0, 0.0));
+  addChild(ModuleLightWidget::create<MediumLight<GreenLight>>(Vec(64.4, 124.4), module, QuadSeq::RESET_LIGHT));
 
-  addInput(createInput<PJ301MPort>(Vec(20, 36), module, QuadSeq::CLOCK_INPUT));
-  addInput(createInput<PJ301MPort>(Vec(20, 79), module, QuadSeq::EXT_CLOCK_INPUT));
-  addInput(createInput<PJ301MPort>(Vec(20, 117), module, QuadSeq::RESET_INPUT));
+  addInput(Port::create<PJ301MPort>(Vec(20, 36), Port::INPUT, module, QuadSeq::CLOCK_INPUT));
+  addInput(Port::create<PJ301MPort>(Vec(20, 79), Port::INPUT, module, QuadSeq::EXT_CLOCK_INPUT));
+  addInput(Port::create<PJ301MPort>(Vec(20, 117), Port::INPUT, module, QuadSeq::RESET_INPUT));
 
 
   for (int i=0;i<NUM_CHANNELS;i++) {
-    //addParam(createParam<RoundSmallBlackKnob>(Vec(135 + i*48, 56), module, QuadSeq::CHANNEL_STEPS_PARAM + i, 1.0, 8.0, 8.0));
-    addParam(createParam<RoundSmallBlackKnob>(Vec(105 + i*55, 50), module, QuadSeq::CHANNEL_STEPS_PARAM + i, 1.0, 8.0, 8.0));
-    addParam(createParam<Trimpot>(Vec(98 + i*55, 105), module, QuadSeq::CHANNEL_RANGE_PARAM + i, 0.0, 1.0, 1.0));
-    addParam(createParam<Trimpot>(Vec(120 + i*55, 105), module, QuadSeq::CHANNEL_MODE_PARAM + i, 0, 5, 0));
-    addInput(createInput<PJ301MPort>(Vec(18 + i*38, 350), module, QuadSeq::CHANNEL_CLOCK_INPUT + i));
-    addOutput(createOutput<PJ301MPort>(Vec(172 + i*38, 350), module, QuadSeq::ROW1_OUTPUT + i));
+    //addParam(ParamWidget::create<RoundSmallBlackKnob>(Vec(135 + i*48, 56), module, QuadSeq::CHANNEL_STEPS_PARAM + i, 1.0, 8.0, 8.0));
+    addParam(ParamWidget::create<RoundSmallBlackKnob>(Vec(105 + i*55, 50), module, QuadSeq::CHANNEL_STEPS_PARAM + i, 1.0, 8.0, 8.0));
+    addParam(ParamWidget::create<Trimpot>(Vec(98 + i*55, 105), module, QuadSeq::CHANNEL_RANGE_PARAM + i, 0.0, 1.0, 1.0));
+    addParam(ParamWidget::create<Trimpot>(Vec(120 + i*55, 105), module, QuadSeq::CHANNEL_MODE_PARAM + i, 0, 5, 0));
+    addInput(Port::create<PJ301MPort>(Vec(18 + i*38, 350), Port::INPUT, module, QuadSeq::CHANNEL_CLOCK_INPUT + i));
+    addOutput(Port::create<PJ301MPort>(Vec(172 + i*38, 350), Port::OUTPUT, module, QuadSeq::ROW1_OUTPUT + i));
     for (int y = 0; y < 8; y++) {
-      //addParam(createParam<RoundSmallBlackKnob>(Vec(18 + y*38 ,175 + i*41), module, QuadSeq::ROW1_PARAM + y + i*8, 0.0, 10.0, 0.0));
-      addParam(createParam<Knob29>(Vec(18 + y*38 ,170 + i*41), module, QuadSeq::ROW1_PARAM + y + i*8, 0.0, 10.0, 0.0));
-      addChild(createLight<SmallLight<RedLight>>(Vec(26.4 + y*38, 200 + i*41), module, QuadSeq::CHANNEL_LIGHTS + y + i*8));
+      //addParam(ParamWidget::create<RoundSmallBlackKnob>(Vec(18 + y*38 ,175 + i*41), module, QuadSeq::ROW1_PARAM + y + i*8, 0.0, 10.0, 0.0));
+      addParam(ParamWidget::create<Knob29>(Vec(18 + y*38 ,170 + i*41), module, QuadSeq::ROW1_PARAM + y + i*8, 0.0, 10.0, 0.0));
+      addChild(ModuleLightWidget::create<SmallLight<RedLight>>(Vec(26.4 + y*38, 200 + i*41), module, QuadSeq::CHANNEL_LIGHTS + y + i*8));
     }
   }
 }
+
+Model *modelQuadSeq = Model::create<QuadSeq, QuadSeqWidget>("Aepelzens Modules", "QuadSeq", "Quad Sequencer", SEQUENCER_TAG);

--- a/src/Walker.cpp
+++ b/src/Walker.cpp
@@ -72,10 +72,14 @@ void Walker::step()
   return;
 }
 
-WalkerWidget::WalkerWidget()
+struct WalkerWidget : ModuleWidget
 {
-  auto *module = new Walker();
-  setModule(module);
+	SVGPanel *panel;
+	WalkerWidget(Walker *module);
+};
+
+WalkerWidget::WalkerWidget(Walker *module) : ModuleWidget(module)
+{
   box.size = Vec(4 * 15, RACK_GRID_HEIGHT);
 
   panel = new SVGPanel();
@@ -83,15 +87,17 @@ WalkerWidget::WalkerWidget()
   panel->setBackground(SVG::load(assetPlugin(plugin, "res/Walker.svg")));
   addChild(panel);
 
-  addParam(createParam<RoundSmallBlackKnob>(Vec(16, 40), module, Walker::STEP_PARAM, 0.0, 1.0, 0.1));
-  addParam(createParam<Trimpot>(Vec(21.5, 80), module, Walker::STEP_ATT_PARAM, -1.0, 1.0, 0));
-  addParam(createParam<RoundSmallBlackKnob>(Vec(16, 110), module, Walker::RANGE_PARAM, 0, 5.0, 2.0));
-  addParam(createParam<Trimpot>(Vec(21.5, 150), module, Walker::RANGE_ATT_PARAM, -1.0, 1.0, 0.0));
-  addParam(createParam<BefacoSwitch>(Vec(16, 172.5), module, Walker::RANGE_MODE_PARAM, 1, 3, 1));
-  addParam(createParam<RoundSmallBlackKnob>(Vec(16, 210), module, Walker::SYM_PARAM, -1.0, 1.0, 0));
+  addParam(ParamWidget::create<RoundSmallBlackKnob>(Vec(16, 40), module, Walker::STEP_PARAM, 0.0, 1.0, 0.1));
+  addParam(ParamWidget::create<Trimpot>(Vec(21.5, 80), module, Walker::STEP_ATT_PARAM, -1.0, 1.0, 0));
+  addParam(ParamWidget::create<RoundSmallBlackKnob>(Vec(16, 110), module, Walker::RANGE_PARAM, 0, 5.0, 2.0));
+  addParam(ParamWidget::create<Trimpot>(Vec(21.5, 150), module, Walker::RANGE_ATT_PARAM, -1.0, 1.0, 0.0));
+  addParam(ParamWidget::create<BefacoSwitch>(Vec(16, 172.5), module, Walker::RANGE_MODE_PARAM, 1, 3, 1));
+  addParam(ParamWidget::create<RoundSmallBlackKnob>(Vec(16, 210), module, Walker::SYM_PARAM, -1.0, 1.0, 0));
 
-  addInput(createInput<PJ301MPort>(Vec(3, 320), module, Walker::CLOCK_INPUT));;
-  addInput(createInput<PJ301MPort>(Vec(3, 276), module, Walker::STEP_INPUT));;
-  addInput(createInput<PJ301MPort>(Vec(30, 276), module, Walker::RANGE_INPUT));;
-  addOutput(createOutput<PJ301MPort>(Vec(30,320), module, Walker::CV_OUTPUT));
+  addInput(Port::create<PJ301MPort>(Vec(3, 320), Port::INPUT, module, Walker::CLOCK_INPUT));;
+  addInput(Port::create<PJ301MPort>(Vec(3, 276), Port::INPUT, module, Walker::STEP_INPUT));;
+  addInput(Port::create<PJ301MPort>(Vec(30, 276), Port::INPUT, module, Walker::RANGE_INPUT));;
+  addOutput(Port::create<PJ301MPort>(Vec(30,320), Port::OUTPUT, module, Walker::CV_OUTPUT));
 }
+
+Model *modelWalker = Model::create<Walker, WalkerWidget>("Aepelzens Modules", "Walker", "Random Walk", UTILITY_TAG, RANDOM_TAG);

--- a/src/aepelzen.cpp
+++ b/src/aepelzen.cpp
@@ -5,17 +5,15 @@ Plugin *plugin;
 
 void init(rack::Plugin *p) {
 	plugin = p;
-	plugin->slug = "Aepelzens Modules";
-#ifdef VERSION
+	plugin->slug = TOSTRING(SLUG);
 	p->version = TOSTRING(VERSION);
-#endif
 
-	p->addModel(createModel<QuadSeqWidget>("Aepelzens Modules", "QuadSeq", "Quad Sequencer", SEQUENCER_TAG));
-	p->addModel(createModel<GateSeqWidget>("Aepelzens Modules", "GateSEQ", "Gate Sequencer", SEQUENCER_TAG));
-	p->addModel(createModel<DiceWidget>("Aepelzens Modules", "Dice", "Probability Sequencer", SEQUENCER_TAG));
-	p->addModel(createModel<BurstWidget>("Aepelzens Modules", "burst", "Burst Generator", SEQUENCER_TAG));
-	p->addModel(createModel<FolderWidget>("Aepelzens Modules", "folder", "Manifold", WAVESHAPER_TAG));
-	p->addModel(createModel<WalkerWidget>("Aepelzens Modules", "Walker", "Random Walk", UTILITY_TAG, RANDOM_TAG));
-	p->addModel(createModel<ErwinWidget>("Aepelzens Modules", "Erwin", "Erwin", UTILITY_TAG));
-	//p->addModel(createModel<dTimeWidget>("Aepelzens Modules", "dTime", "dTime Sequencer", SEQUENCER_TAG));
+	p->addModel(modelQuadSeq);
+	p->addModel(modelGateSeq);
+	p->addModel(modelDice);
+	p->addModel(modelBurst);
+	p->addModel(modelFolder);
+	p->addModel(modelWalker);
+	p->addModel(modelErwin);
+	//p->addModel(modeldTime);
 }

--- a/src/aepelzen.hpp
+++ b/src/aepelzen.hpp
@@ -4,18 +4,6 @@ using namespace rack;
 
 extern Plugin *plugin;
 
-////////////////////
-// module widgets
-////////////////////
-
-struct GateSeqWidget : ModuleWidget {
-	GateSeqWidget();
-};
-
-struct QuadSeqWidget : ModuleWidget {
-	QuadSeqWidget();
-};
-
 // struct dTimeWidget : ModuleWidget {
 // 	dTimeWidget();
 // };
@@ -27,30 +15,11 @@ struct Knob29 : RoundKnob {
 	}
 };
 
-struct BurstWidget : ModuleWidget
-{
-	SVGPanel *panel;
-	BurstWidget();
-  //void step() override;
-};
-
-struct FolderWidget : ModuleWidget
-{
-	SVGPanel *panel;
-	FolderWidget();
-	Menu *createContextMenu() override;
-};
-
-struct WalkerWidget : ModuleWidget
-{
-	SVGPanel *panel;
-	WalkerWidget();
-};
-
-struct ErwinWidget : ModuleWidget {
-	ErwinWidget();
-};
-
-struct DiceWidget : ModuleWidget {
-	DiceWidget();
-};
+extern Model *modelQuadSeq;
+extern Model *modelGateSeq;
+extern Model *modelDice;
+extern Model *modelBurst;
+extern Model *modelFolder;
+extern Model *modelWalker;
+extern Model *modelErwin;
+extern Model *modeldTime;

--- a/src/burst.cpp
+++ b/src/burst.cpp
@@ -204,10 +204,15 @@ void Burst::step()
 }
 
 
-BurstWidget::BurstWidget()
+struct BurstWidget : ModuleWidget
 {
-  auto *module = new Burst();
-  setModule(module);
+	SVGPanel *panel;
+	BurstWidget(Burst *module);
+  //void step() override;
+};
+
+BurstWidget::BurstWidget(Burst *module) : ModuleWidget(module)
+{
   //box.size = Vec(6 * RACK_GRID_WIDTH, RACK_GRID_HEIGHT);
   box.size = Vec(6 * 15, RACK_GRID_HEIGHT);
 
@@ -216,31 +221,33 @@ BurstWidget::BurstWidget()
   panel->setBackground(SVG::load(assetPlugin(plugin, "res/Burst.svg")));
   addChild(panel);
 
-  // addChild(createScrew<ScrewSilver>(Vec(15, 0)));
-  // addChild(createScrew<ScrewSilver>(Vec(box.size.x - 30, 0)));
-  // addChild(createScrew<ScrewSilver>(Vec(15, 365)));
-  // addChild(createScrew<ScrewSilver>(Vec(box.size.x - 30, 365)));
+  // addChild(Widget::create<ScrewSilver>(Vec(15, 0)));
+  // addChild(Widget::create<ScrewSilver>(Vec(box.size.x - 30, 0)));
+  // addChild(Widget::create<ScrewSilver>(Vec(15, 365)));
+  // addChild(Widget::create<ScrewSilver>(Vec(box.size.x - 30, 365)));
 
   //note: SmallKnob size = 28px, Trimpot = 17 px
-  //addParam(createParam<LEDBezel>(Vec(30, 105), module, Burst::BUTTON_PARAM, 0.0, 1.0, 0.0));
-  addParam(createParam<CKD6>(Vec(30, 105), module, Burst::BUTTON_PARAM, 0.0, 1.0, 0.0));
-  //addParam(createParam<RoundSmallBlackKnob>(Vec(35, 50), module, Burst::REP_PARAM, 1, 8, 4));
-  addParam(createParam<Davies1900hLargeBlackKnob>(Vec(18, 30), module, Burst::REP_PARAM, 0, 8, 4));
-  addParam(createParam<RoundSmallBlackKnob>(Vec(10, 150), module, Burst::TIME_PARAM, 0.02, 1, 0.5));
-  addParam(createParam<RoundSmallBlackKnob>(Vec(52, 150), module, Burst::ACCEL_PARAM, 1.0, 2.0, 1.0));
-  addParam(createParam<RoundSmallBlackKnob>(Vec(10, 195), module, Burst::JITTER_PARAM, 0.0, 1.0, 0.0));
-  addParam(createParam<RoundSmallBlackKnob>(Vec(52, 195), module, Burst::CV_MODE_PARAM, 0, 6, 0));
+  //addParam(ParamWidget::create<LEDBezel>(Vec(30, 105), module, Burst::BUTTON_PARAM, 0.0, 1.0, 0.0));
+  addParam(ParamWidget::create<CKD6>(Vec(30, 105), module, Burst::BUTTON_PARAM, 0.0, 1.0, 0.0));
+  //addParam(ParamWidget::create<RoundSmallBlackKnob>(Vec(35, 50), module, Burst::REP_PARAM, 1, 8, 4));
+  addParam(ParamWidget::create<Davies1900hLargeBlackKnob>(Vec(18, 30), module, Burst::REP_PARAM, 0, 8, 4));
+  addParam(ParamWidget::create<RoundSmallBlackKnob>(Vec(10, 150), module, Burst::TIME_PARAM, 0.02, 1, 0.5));
+  addParam(ParamWidget::create<RoundSmallBlackKnob>(Vec(52, 150), module, Burst::ACCEL_PARAM, 1.0, 2.0, 1.0));
+  addParam(ParamWidget::create<RoundSmallBlackKnob>(Vec(10, 195), module, Burst::JITTER_PARAM, 0.0, 1.0, 0.0));
+  addParam(ParamWidget::create<RoundSmallBlackKnob>(Vec(52, 195), module, Burst::CV_MODE_PARAM, 0, 6, 0));
 
-  addParam(createParam<Trimpot>(Vec(15.5, 240), module, Burst::REP_ATT_PARAM, -1.0, 1.0, 0.0));
-  addParam(createParam<Trimpot>(Vec(54, 240), module, Burst::TIME_ATT_PARAM, -1.0, 1.0, 0.0));
-  addInput(createInput<PJ301MPort>(Vec(13, 265), module, Burst::REP_INPUT));;
-  addInput(createInput<PJ301MPort>(Vec(50, 265), module, Burst::TIME_INPUT));;
+  addParam(ParamWidget::create<Trimpot>(Vec(15.5, 240), module, Burst::REP_ATT_PARAM, -1.0, 1.0, 0.0));
+  addParam(ParamWidget::create<Trimpot>(Vec(54, 240), module, Burst::TIME_ATT_PARAM, -1.0, 1.0, 0.0));
+  addInput(Port::create<PJ301MPort>(Vec(13, 265), Port::INPUT, module, Burst::REP_INPUT));;
+  addInput(Port::create<PJ301MPort>(Vec(50, 265), Port::INPUT, module, Burst::TIME_INPUT));;
 
-  addInput(createInput<PJ301MPort>(Vec(5, 305), module, Burst::GATE_INPUT));;
-  addInput(createInput<PJ301MPort>(Vec(60, 305), module, Burst::CLOCK_INPUT));;
-  addParam(createParam<CKSS>(Vec(38, 300), module, Burst::GATE_MODE_PARAM, 0.0, 1.0, 0.0));
+  addInput(Port::create<PJ301MPort>(Vec(5, 305), Port::INPUT, module, Burst::GATE_INPUT));;
+  addInput(Port::create<PJ301MPort>(Vec(60, 305), Port::INPUT, module, Burst::CLOCK_INPUT));;
+  addParam(ParamWidget::create<CKSS>(Vec(38, 300), module, Burst::GATE_MODE_PARAM, 0.0, 1.0, 0.0));
 
-  addOutput(createOutput<PJ301MPort>(Vec(5,335), module, Burst::CV_OUTPUT));
-  addOutput(createOutput<PJ301MPort>(Vec(32.5,335), module, Burst::EOC_OUTPUT));
-  addOutput(createOutput<PJ301MPort>(Vec(60,335), module, Burst::GATE_OUTPUT));
+  addOutput(Port::create<PJ301MPort>(Vec(5,335), Port::OUTPUT, module, Burst::CV_OUTPUT));
+  addOutput(Port::create<PJ301MPort>(Vec(32.5,335), Port::OUTPUT, module, Burst::EOC_OUTPUT));
+  addOutput(Port::create<PJ301MPort>(Vec(60,335), Port::OUTPUT, module, Burst::GATE_OUTPUT));
 }
+
+Model *modelBurst = Model::create<Burst, BurstWidget>("Aepelzens Modules", "burst", "Burst Generator", SEQUENCER_TAG);

--- a/src/folder.cpp
+++ b/src/folder.cpp
@@ -88,7 +88,7 @@ struct Folder : Module
 float fold(float in, float threshold) {
   float out;
   if (in>threshold || in<-threshold) {
-    out = clampf(fabs(fabs(fmod(in - threshold, threshold*4)) - threshold*2) - threshold, -5.0,5.0); 
+    out = clampf(fabs(fabs(fmod(in - threshold, threshold*4)) - threshold*2) - threshold, -5.0,5.0);
   }
   else {
     out = in;
@@ -166,10 +166,16 @@ void Folder::step()
   return;
 }
 
-FolderWidget::FolderWidget()
+
+struct FolderWidget : ModuleWidget
 {
-  auto *module = new Folder();
-  setModule(module);
+	SVGPanel *panel;
+	FolderWidget(Folder *module);
+	Menu *createContextMenu() override;
+};
+
+FolderWidget::FolderWidget(Folder *module) : ModuleWidget(module)
+{
   //box.size = Vec(6 * RACK_GRID_WIDTH, RACK_GRID_HEIGHT);
   box.size = Vec(4 * 15, RACK_GRID_HEIGHT);
 
@@ -178,23 +184,23 @@ FolderWidget::FolderWidget()
   panel->setBackground(SVG::load(assetPlugin(plugin, "res/Folder.svg")));
   addChild(panel);
 
-  // addChild(createScrew<ScrewSilver>(Vec(15, 0)));
-  // addChild(createScrew<ScrewSilver>(Vec(box.size.x - 30, 0)));
-  // addChild(createScrew<ScrewSilver>(Vec(15, 365)));
-  // addChild(createScrew<ScrewSilver>(Vec(box.size.x - 30, 365)));
+  // addChild(Widget::create<ScrewSilver>(Vec(15, 0)));
+  // addChild(Widget::create<ScrewSilver>(Vec(box.size.x - 30, 0)));
+  // addChild(Widget::create<ScrewSilver>(Vec(15, 365)));
+  // addChild(Widget::create<ScrewSilver>(Vec(box.size.x - 30, 365)));
 
   //note: SmallKnob size = 28px, Trimpot = 17 px
-  addParam(createParam<BefacoSwitch>(Vec(16, 50), module, Folder::STAGE_PARAM, 1, 3, 2));
-  addParam(createParam<RoundSmallBlackKnob>(Vec(16, 100), module, Folder::GAIN_PARAM, 0.0, 14.0, 1.0));
-  addParam(createParam<Trimpot>(Vec(21.5, 145), module, Folder::GAIN_ATT_PARAM, -1.0, 1.0, 0));
-  addParam(createParam<RoundSmallBlackKnob>(Vec(16, 185), module, Folder::SYM_PARAM, -1.0, 1.0, 0.0));
-  addParam(createParam<Trimpot>(Vec(21.5, 230), module, Folder::SYM_ATT_PARAM, -1.0, 1.0, 0.0));
+  addParam(ParamWidget::create<BefacoSwitch>(Vec(16, 50), module, Folder::STAGE_PARAM, 1, 3, 2));
+  addParam(ParamWidget::create<RoundSmallBlackKnob>(Vec(16, 100), module, Folder::GAIN_PARAM, 0.0, 14.0, 1.0));
+  addParam(ParamWidget::create<Trimpot>(Vec(21.5, 145), module, Folder::GAIN_ATT_PARAM, -1.0, 1.0, 0));
+  addParam(ParamWidget::create<RoundSmallBlackKnob>(Vec(16, 185), module, Folder::SYM_PARAM, -1.0, 1.0, 0.0));
+  addParam(ParamWidget::create<Trimpot>(Vec(21.5, 230), module, Folder::SYM_ATT_PARAM, -1.0, 1.0, 0.0));
 
 
-  addInput(createInput<PJ301MPort>(Vec(3, 320), module, Folder::GATE_INPUT));;
-  addInput(createInput<PJ301MPort>(Vec(3, 276), module, Folder::GAIN_INPUT));;
-  addInput(createInput<PJ301MPort>(Vec(30, 276), module, Folder::SYM_INPUT));;
-  addOutput(createOutput<PJ301MPort>(Vec(30,320), module, Folder::GATE_OUTPUT));
+  addInput(Port::create<PJ301MPort>(Vec(3, 320), Port::INPUT, module, Folder::GATE_INPUT));;
+  addInput(Port::create<PJ301MPort>(Vec(3, 276), Port::INPUT, module, Folder::GAIN_INPUT));;
+  addInput(Port::create<PJ301MPort>(Vec(30, 276), Port::INPUT, module, Folder::SYM_INPUT));;
+  addOutput(Port::create<PJ301MPort>(Vec(30,320), Port::OUTPUT, module, Folder::GATE_OUTPUT));
 }
 
 struct FolderMenuItem : MenuItem {
@@ -219,3 +225,5 @@ Menu *FolderWidget::createContextMenu() {
 
 	return menu;
 }
+
+Model *modelFolder = Model::create<Folder, FolderWidget>("Aepelzens Modules", "folder", "Manifold", WAVESHAPER_TAG);


### PR DESCRIPTION
Update plugin to Rack API v0.6 incl. updated Makefile (reference: [Repair Team](https://github.com/VCVRack/community/issues/269)).

Note: Rack v0.6 does **not** build against `libsamplerate` anymore. I did not update the sample rate converter code, but built against `libsamplerate` for testing. The code should maybe be updated to use Rack's `SampleRateConverter` class in `samplerate.hpp`.