### PR TITLE
Makefile update (compiles dep libsamplerate)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,26 @@
-SLUG = "Aepelzens Modules"
-VERSION = 0.6.0dev
+RACK_DIR ?= ../..
+SLUG = AepelzensModules
+VERSION = 0.6.0
 
-#FLAGS += -D v_050_dev
-
-LDFLAGS += -lsamplerate
-
+FLAGS += -Idep/include
 SOURCES += $(wildcard src/*.cpp)
-
 DISTRIBUTABLES += $(wildcard LICENSE*) res
 
-RACK_DIR ?= ../..
+# Static libs
+libsamplerate := dep/lib/libsamplerate.a
+OBJECTS += $(libsamplerate)
+
+# Dependencies
+$(shell mkdir -p dep)
+DEP_LOCAL := dep
+DEPS += $(libsamplerate)
+
+$(libsamplerate):
+	cd dep && $(WGET) http://www.mega-nerd.com/SRC/libsamplerate-0.1.9.tar.gz
+	cd dep && $(UNTAR) libsamplerate-0.1.9.tar.gz
+	cd dep/libsamplerate-0.1.9 && $(CONFIGURE)
+	cd dep/libsamplerate-0.1.9 && $(MAKE)
+	cd dep/libsamplerate-0.1.9 && $(MAKE) install
+
+
 include $(RACK_DIR)/plugin.mk


### PR DESCRIPTION
Hi, this makefile is like the latest found on Fundamental modules (still using dep libsamplerate) and compiles fine in the latest v.06 rack